### PR TITLE
Switch from pyup.io to Dependabot

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,4 +1,0 @@
-schedule: "every month"
-requirements:
-  - Pipfile
-  - Pipfile.lock

--- a/README.rst
+++ b/README.rst
@@ -16,9 +16,9 @@ a set of API to interact with them.
 .. image:: https://img.shields.io/coveralls/github/mozilla/servicebook/master.svg
    :alt: Coverage
    :target: https://coveralls.io/github/mozilla/servicebook?branch=master
-.. image:: https://pyup.io/repos/github/mozilla/servicebook/shield.svg
-   :target: https://pyup.io/repos/github/mozilla/servicebook
-   :alt: Updates
+.. image:: https://api.dependabot.com/badges/status?host=github&repo=mozilla/servicebook-web
+   :target: https://dependabot.com
+   :alt: Dependabot
 
 Use the Service Book
 --------------------

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ a set of API to interact with them.
 .. image:: https://img.shields.io/coveralls/github/mozilla/servicebook/master.svg
    :alt: Coverage
    :target: https://coveralls.io/github/mozilla/servicebook?branch=master
-.. image:: https://api.dependabot.com/badges/status?host=github&repo=mozilla/servicebook-web
+.. image:: https://api.dependabot.com/badges/status?host=github&repo=mozilla/servicebook
    :target: https://dependabot.com
    :alt: Dependabot
 


### PR DESCRIPTION
EDIT: actually, looks like it was already switched (perhaps accidentally, or by me? I dunno), as early as September 1st: https://github.com/mozilla/servicebook/pull/144

Anyway, I'm so far loving Dependabot, and have moved a bunch of repos over.

r?  @davehunt @tarekziade 